### PR TITLE
Copy RetryExecutor from embulk-core, and replace subprojects' dependencies to the root project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build
-      run: ./gradlew --stacktrace embulk-util-retryhelper-jaxrs:jar embulk-util-retryhelper-jetty92:jar embulk-util-retryhelper-jetty93:jar
+      run: ./gradlew --stacktrace :jar embulk-util-retryhelper-jaxrs:jar embulk-util-retryhelper-jetty92:jar embulk-util-retryhelper-jetty93:jar

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,120 @@
 plugins {
     id "java"
+    id "maven-publish"
+    id "signing"
 }
 
 group = "org.embulk"
 version = "0.8.0-SNAPSHOT"
+description = "Utility library to retry HTTP requests"
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+configurations {
+    compileClasspath.resolutionStrategy.activateDependencyLocking()
+    runtimeClasspath.resolutionStrategy.activateDependencyLocking()
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    options.encoding = "UTF-8"
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+javadoc {
+    title = "${project.name} v${project.version}"
+    options {
+        locale = "en_US"
+        encoding = "UTF-8"
+        overview = "src/main/html/overview.html"
+        links "https://docs.oracle.com/javase/8/docs/api/"
+    }
+}
+
+jar {
+    from rootProject.file("LICENSE")
+}
+
+sourcesJar {
+    from rootProject.file("LICENSE")
+}
+
+javadocJar {
+    from rootProject.file("LICENSE")
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = "${project.group}"
+            artifactId = "${project.name}"
+
+            from components.java
+            // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
+            // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
+
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                packaging "jar"
+
+                name = "${project.name}"
+                description = "${project.description}"
+                url = "https://www.embulk.org/"
+
+                licenses {
+                    license {
+                        // http://central.sonatype.org/pages/requirements.html#license-information
+                        name = "The Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+
+                developers {
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+
+                scm {
+                    connection = "scm:git:git://github.com/embulk/embulk-util-retryhelper.git"
+                    developerConnection = "scm:git:git@github.com:embulk/embulk-util-retryhelper.git"
+                    url = "https://github.com/embulk/embulk-util-retryhelper"
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {  // publishMavenPublicationToMavenCentralRepository
+            name = "mavenCentral"
+            if (project.version.endsWith("-SNAPSHOT")) {
+                url "https://oss.sonatype.org/content/repositories/snapshots"
+            } else {
+                url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            }
+
+            credentials {
+                username = project.hasProperty("ossrhUsername") ? ossrhUsername : ""
+                password = project.hasProperty("ossrhPassword") ? ossrhPassword : ""
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.maven
+}

--- a/embulk-util-retryhelper-jaxrs/build.gradle
+++ b/embulk-util-retryhelper-jaxrs/build.gradle
@@ -22,8 +22,9 @@ repositories {
 }
 
 dependencies {
-    compile "org.embulk:embulk-api:0.10.5"
-    compile "org.embulk:embulk-core:0.10.5"
+    compile project(":")
+    compile "com.google.guava:guava:18.0"
+    compile "org.slf4j:slf4j-api:1.7.12"
 
     compile     'javax.ws.rs:javax.ws.rs-api:2.0.1'
 }

--- a/embulk-util-retryhelper-jaxrs/src/main/java/org/embulk/util/retryhelper/jaxrs/JAXRSRetryHelper.java
+++ b/embulk-util-retryhelper-jaxrs/src/main/java/org/embulk/util/retryhelper/jaxrs/JAXRSRetryHelper.java
@@ -4,8 +4,8 @@ import java.util.Locale;
 
 import com.google.common.base.Throwables;
 
-import org.embulk.spi.Exec;
 import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.LoggerFactory;
 
 public class JAXRSRetryHelper
         implements AutoCloseable
@@ -20,7 +20,7 @@ public class JAXRSRetryHelper
              maximumRetryIntervalMillis,
              clientCreator.create(),
              true,
-             Exec.getLogger(JAXRSRetryHelper.class));
+             LoggerFactory.getLogger(JAXRSRetryHelper.class));
     }
 
     public JAXRSRetryHelper(int maximumRetries,

--- a/embulk-util-retryhelper-jetty92/build.gradle
+++ b/embulk-util-retryhelper-jetty92/build.gradle
@@ -22,8 +22,9 @@ repositories {
 }
 
 dependencies {
-    compile "org.embulk:embulk-api:0.10.5"
-    compile "org.embulk:embulk-core:0.10.5"
+    compile project(":")
+    compile "com.google.guava:guava:18.0"
+    compile "org.slf4j:slf4j-api:1.7.12"
 
     compile     'org.eclipse.jetty:jetty-client:9.2.14.v20151106'
 }

--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
@@ -11,8 +11,8 @@ import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import org.embulk.spi.Exec;
 import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.LoggerFactory;
 
 public class Jetty92RetryHelper
         implements AutoCloseable
@@ -32,7 +32,7 @@ public class Jetty92RetryHelper
             throw new RuntimeException(ex);
         }
         this.closeAutomatically = true;
-        this.logger = Exec.getLogger(Jetty92RetryHelper.class);
+        this.logger = LoggerFactory.getLogger(Jetty92RetryHelper.class);
     }
 
     public Jetty92RetryHelper(int maximumRetries,

--- a/embulk-util-retryhelper-jetty93/build.gradle
+++ b/embulk-util-retryhelper-jetty93/build.gradle
@@ -22,8 +22,9 @@ repositories {
 }
 
 dependencies {
-    compile "org.embulk:embulk-api:0.10.5"
-    compile "org.embulk:embulk-core:0.10.5"
+    compile project(":")
+    compile "com.google.guava:guava:18.0"
+    compile "org.slf4j:slf4j-api:1.7.12"
 
     compile     'org.eclipse.jetty:jetty-client:9.3.16.v20170120'
 }

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
@@ -11,8 +11,8 @@ import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import org.embulk.spi.Exec;
 import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.LoggerFactory;
 
 public class Jetty93RetryHelper
         implements AutoCloseable
@@ -32,7 +32,7 @@ public class Jetty93RetryHelper
             throw new RuntimeException(ex);
         }
         this.closeAutomatically = true;
-        this.logger = Exec.getLogger(Jetty93RetryHelper.class);
+        this.logger = LoggerFactory.getLogger(Jetty93RetryHelper.class);
     }
 
     public Jetty93RetryHelper(int maximumRetries,

--- a/src/main/html/overview.html
+++ b/src/main/html/overview.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>embulk-util-retryhelper</title>
+  </head>
+  <body>
+    <p>Utility library to retry.</p>
+  </body>
+</html>

--- a/src/main/java/org/embulk/spi/util/RetryExecutor.java
+++ b/src/main/java/org/embulk/spi/util/RetryExecutor.java
@@ -1,0 +1,110 @@
+package org.embulk.spi.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class RetryExecutor {
+    public static RetryExecutor retryExecutor() {
+        // TODO default configuration
+        return new RetryExecutor(3, 500, 30 * 60 * 1000);
+    }
+
+    public static class RetryGiveupException extends ExecutionException {
+        public RetryGiveupException(String message, Exception cause) {
+            super(cause);
+        }
+
+        public RetryGiveupException(Exception cause) {
+            super(cause);
+        }
+
+        public Exception getCause() {
+            return (Exception) super.getCause();
+        }
+    }
+
+    public static interface Retryable<T> extends Callable<T> {
+        public T call() throws Exception;
+
+        public boolean isRetryableException(Exception exception);
+
+        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                throws RetryGiveupException;
+
+        public void onGiveup(Exception firstException, Exception lastException)
+                throws RetryGiveupException;
+    }
+
+    private final int retryLimit;
+    private final int initialRetryWait;
+    private final int maxRetryWait;
+
+    private RetryExecutor(int retryLimit, int initialRetryWait, int maxRetryWait) {
+        this.retryLimit = retryLimit;
+        this.initialRetryWait = initialRetryWait;
+        this.maxRetryWait = maxRetryWait;
+    }
+
+    public RetryExecutor withRetryLimit(int count) {
+        return new RetryExecutor(count, initialRetryWait, maxRetryWait);
+    }
+
+    public RetryExecutor withInitialRetryWait(int msec) {
+        return new RetryExecutor(retryLimit, msec, maxRetryWait);
+    }
+
+    public RetryExecutor withMaxRetryWait(int msec) {
+        return new RetryExecutor(retryLimit, initialRetryWait, msec);
+    }
+
+    public <T> T runInterruptible(Retryable<T> op)
+            throws InterruptedException, RetryGiveupException {
+        return run(op, true);
+    }
+
+    public <T> T run(Retryable<T> op) throws RetryGiveupException {
+        try {
+            return run(op, false);
+        } catch (InterruptedException ex) {
+            throw new RetryGiveupException("Unexpected interruption", ex);
+        }
+    }
+
+    private <T> T run(Retryable<T> op, boolean interruptible) throws InterruptedException, RetryGiveupException {
+        int retryWait = initialRetryWait;
+        int retryCount = 0;
+
+        Exception firstException = null;
+
+        while (true) {
+            try {
+                return op.call();
+            } catch (Exception exception) {
+                if (firstException == null) {
+                    firstException = exception;
+                }
+                if (!op.isRetryableException(exception) || retryCount >= retryLimit) {
+                    op.onGiveup(firstException, exception);
+                    throw new RetryGiveupException(firstException);
+                }
+
+                retryCount++;
+                op.onRetry(exception, retryCount, retryLimit, retryWait);
+
+                try {
+                    Thread.sleep(retryWait);
+                } catch (InterruptedException ex) {
+                    if (interruptible) {
+                        throw ex;
+                    }
+                }
+
+                // exponential back-off with hard limit
+                retryWait *= 2;
+                if (retryWait > maxRetryWait) {
+                    retryWait = maxRetryWait;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
It replaces `Exec.getLogger` to `LoggerFactory.getLogger` along with it.

`org.embulk.spi.util.RetryExecutor` in `embulk-core` is just a utility class for plugins. It does not need to be in `embulk-core`. `RetryExecutor` is to be refactored out from `embulk-core` like other `embulk-util-config` and `embulk-util-timestamp` as described in: https://dev.embulk.org/topics/catchup-with-v0.10.html

Moving `RetryExecutor` into this `embulk-util-retryhelper` as it is strongly related with `RetryExecutor`.

This Pull Request just copies it. It is going to be refactored in next PRs.