### PR TITLE
Propagate cause of RetryGiveupException as-is if it's already a RuntimeException.

### DIFF
--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
@@ -177,6 +177,9 @@ public class Jetty92RetryHelper
         }
         catch (RetryGiveupException ex) {
             // RetryGiveupException is ExecutionException, which must not be RuntimeException.
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
             throw new RuntimeException(ex.getCause());
         }
     }

--- a/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
+++ b/embulk-util-retryhelper-jetty92/src/main/java/org/embulk/util/retryhelper/jetty92/Jetty92RetryHelper.java
@@ -176,7 +176,6 @@ public class Jetty92RetryHelper
             throw new RuntimeException(ex);
         }
         catch (RetryGiveupException ex) {
-            // RetryGiveupException is ExecutionException, which must not be RuntimeException.
             if (ex.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) ex.getCause();
             }

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
@@ -176,7 +176,6 @@ public class Jetty93RetryHelper
             throw new RuntimeException(ex);
         }
         catch (RetryGiveupException ex) {
-            // RetryGiveupException is ExecutionException, which must not be RuntimeException.
             if (ex.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) ex.getCause();
             }

--- a/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
+++ b/embulk-util-retryhelper-jetty93/src/main/java/org/embulk/util/retryhelper/jetty93/Jetty93RetryHelper.java
@@ -177,6 +177,9 @@ public class Jetty93RetryHelper
         }
         catch (RetryGiveupException ex) {
             // RetryGiveupException is ExecutionException, which must not be RuntimeException.
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
             throw new RuntimeException(ex.getCause());
         }
     }


### PR DESCRIPTION
This is to roll back the old behavior of v0.7.0.
Earlier in v0.7.0, if retrying was gave up and the direct cause is already an unchecked exception, it would be propagated as is.
In v0.8.0, under the same circumstance, the direct cause would be wrapped in an extra RuntimeException regardless of whether is' a checked or an unchecked exception.