### PR TITLE
Add Jetty client 9.4 to support TLS1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build
-      run: ./gradlew --stacktrace :jar embulk-util-retryhelper-jaxrs:jar embulk-util-retryhelper-jetty92:jar embulk-util-retryhelper-jetty93:jar
+      run: ./gradlew --stacktrace :jar embulk-util-retryhelper-jaxrs:jar embulk-util-retryhelper-jetty92:jar embulk-util-retryhelper-jetty93:jar embulk-util-retryhelper-jetty94:jar

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Release 0.8.3 - 2023-08-09
+Release 0.9.0 - 2023-08-09
 
 * [update] Add jetty94 to support TLS1.3
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 0.8.3 - 2023-08-09
+
+* [update] Add jetty94 to support TLS1.3
+
 Release 0.7.0 - 2019-08-09
 
 * [incompatibility] Built for Embulk v0.9 and Java 8.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.8.3-SNAPSHOT"
+version = "0.9.0-SNAPSHOT"
 description = "Utility library to retry HTTP requests"
 
 sourceCompatibility = 1.8

--- a/embulk-util-retryhelper-jetty94/build.gradle
+++ b/embulk-util-retryhelper-jetty94/build.gradle
@@ -1,12 +1,13 @@
 plugins {
     id "java"
+    id "java-library"
     id "maven-publish"
     id "signing"
 }
 
-group = "org.embulk"
-version = "0.8.3-SNAPSHOT"
-description = "Utility library to retry HTTP requests"
+group = "${rootProject.group}"
+version = "${rootProject.version}"
+description = "Utility library to retry HTTP requests through Jetty 9.4 client with Embulk RetryExecutor"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -18,6 +19,13 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+dependencies {
+    compileOnly "org.slf4j:slf4j-api:1.7.30"
+
+    api project(":")
+    api "org.eclipse.jetty:jetty-client:9.4.51.v20230217"
 }
 
 tasks.withType(JavaCompile) {
@@ -86,6 +94,10 @@ publishing {
                         name = "Dai MIKURUBE"
                         email = "dmikurube@treasure-data.com"
                     }
+                    developer {
+                        name = "Thanh Le"
+                        email = "thanh.le@treasure-data.com"
+                    }
                 }
 
                 scm {
@@ -117,3 +129,4 @@ publishing {
 signing {
     sign publishing.publications.maven
 }
+

--- a/embulk-util-retryhelper-jetty94/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-util-retryhelper-jetty94/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,8 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.eclipse.jetty:jetty-client:9.4.51.v20230217
+org.eclipse.jetty:jetty-http:9.4.51.v20230217
+org.eclipse.jetty:jetty-io:9.4.51.v20230217
+org.eclipse.jetty:jetty-util:9.4.51.v20230217
+org.slf4j:slf4j-api:1.7.30

--- a/embulk-util-retryhelper-jetty94/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/embulk-util-retryhelper-jetty94/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.eclipse.jetty:jetty-client:9.4.51.v20230217
+org.eclipse.jetty:jetty-http:9.4.51.v20230217
+org.eclipse.jetty:jetty-io:9.4.51.v20230217
+org.eclipse.jetty:jetty-util:9.4.51.v20230217

--- a/embulk-util-retryhelper-jetty94/src/main/html/overview.html
+++ b/embulk-util-retryhelper-jetty94/src/main/html/overview.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>embulk-util-retryhelper-jetty94</title>
+  </head>
+  <body>
+    <p>Utility library to retry HTTP requests through Jetty 9.4 client with Embulk RetryExecutor.</p>
+  </body>
+</html>

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/DefaultJetty94ClientCreator.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/DefaultJetty94ClientCreator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+public final class DefaultJetty94ClientCreator
+        implements Jetty94ClientCreator
+{
+    public DefaultJetty94ClientCreator(int connectTimeout,
+                                       int idleTimeout)
+    {
+        this(new SslContextFactory(), connectTimeout, idleTimeout, true);
+    }
+
+    public DefaultJetty94ClientCreator(int connectTimeout,
+                                       int idleTimeout,
+                                       boolean tcpNoDelay)
+    {
+        this(new SslContextFactory(), connectTimeout, idleTimeout, tcpNoDelay);
+    }
+
+    public DefaultJetty94ClientCreator(SslContextFactory sslContextFactory,
+                                       int connectTimeout,
+                                       int idleTimeout)
+    {
+        this(sslContextFactory, connectTimeout, idleTimeout, true);
+    }
+
+    public DefaultJetty94ClientCreator(SslContextFactory sslContextFactory,
+                                       int connectTimeout,
+                                       int idleTimeout,
+                                       boolean tcpNoDelay)
+    {
+        this.sslContextFactory = sslContextFactory;
+        this.connectTimeout = connectTimeout;
+        this.idleTimeout = idleTimeout;
+        this.tcpNoDelay = tcpNoDelay;
+    }
+
+    @Override
+    public HttpClient createAndStart()
+            throws Exception
+    {
+        HttpClient client = new HttpClient(this.sslContextFactory);
+        client.setConnectTimeout(this.connectTimeout);
+        client.setIdleTimeout(this.idleTimeout);
+        client.setTCPNoDelay(this.tcpNoDelay);
+        client.start();
+        return client;
+    }
+
+    private final SslContextFactory sslContextFactory;
+    private final int connectTimeout;
+    private final int idleTimeout;
+    private final boolean tcpNoDelay;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/InputStreamJetty94ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/InputStreamJetty94ResponseEntityReader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
+
+public class InputStreamJetty94ResponseEntityReader
+        implements Jetty94ResponseReader<InputStream>
+{
+    public InputStreamJetty94ResponseEntityReader(long timeoutMillis)
+    {
+        this.listener = new InputStreamResponseListener();
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    @Override
+    public final Response.Listener getListener()
+    {
+        return this.listener;
+    }
+
+    @Override
+    public final Response getResponse()
+            throws Exception
+    {
+        return this.listener.get(this.timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public final InputStream readResponseContent()
+            throws Exception
+    {
+        return this.listener.getInputStream();
+    }
+
+    @Override
+    public final String readResponseContentInString()
+            throws Exception
+    {
+        return Util.asString(this.readResponseContent());
+    }
+
+    private final InputStreamResponseListener listener;
+    private final long timeoutMillis;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ClientCreator.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ClientCreator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import org.eclipse.jetty.client.HttpClient;
+
+public interface Jetty94ClientCreator
+{
+    HttpClient createAndStart() throws Exception;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ResponseReader.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ResponseReader.java
@@ -19,9 +19,9 @@ package org.embulk.util.retryhelper.jetty94;
 import org.eclipse.jetty.client.api.Response;
 
 /**
- * Jetty93ResponseReader defines methods that read (understand) Jetty 9.3's response through {@code Listener}s.
+ * Jetty94ResponseReader defines methods that read (understand) Jetty 9.4's response through {@code Listener}s.
  *
- * Find some predefined {@code Jetty93ResponseReader}s such as {@code StringJetty93ResponseEntityReader}.
+ * Find some predefined {@code Jetty94ResponseReader}s such as {@code StringJetty94ResponseEntityReader}.
  */
 public interface Jetty94ResponseReader<T>
 {

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ResponseReader.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94ResponseReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import org.eclipse.jetty.client.api.Response;
+
+/**
+ * Jetty93ResponseReader defines methods that read (understand) Jetty 9.3's response through {@code Listener}s.
+ *
+ * Find some predefined {@code Jetty93ResponseReader}s such as {@code StringJetty93ResponseEntityReader}.
+ */
+public interface Jetty94ResponseReader<T>
+{
+    Response.Listener getListener();
+    Response getResponse() throws Exception;
+    T readResponseContent() throws Exception;
+    String readResponseContentInString() throws Exception;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94RetryHelper.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94RetryHelper.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import java.util.Locale;
+import org.eclipse.jetty.client.HttpResponseException;
+import org.eclipse.jetty.client.api.Response;
+import org.embulk.util.retryhelper.Retryable;
+import org.embulk.util.retryhelper.RetryExecutor;
+import org.embulk.util.retryhelper.RetryGiveupException;
+import org.slf4j.LoggerFactory;
+
+public class Jetty94RetryHelper
+        implements AutoCloseable
+{
+    public Jetty94RetryHelper(int maximumRetries,
+                              int initialRetryIntervalMillis,
+                              int maximumRetryIntervalMillis,
+                              Jetty94ClientCreator clientCreator)
+    {
+        this.maximumRetries = maximumRetries;
+        this.initialRetryIntervalMillis = initialRetryIntervalMillis;
+        this.maximumRetryIntervalMillis = maximumRetryIntervalMillis;
+        try {
+            this.clientStarted = clientCreator.createAndStart();
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        this.closeAutomatically = true;
+        this.logger = LoggerFactory.getLogger(Jetty94RetryHelper.class);
+    }
+
+    public Jetty94RetryHelper(int maximumRetries,
+                              int initialRetryIntervalMillis,
+                              int maximumRetryIntervalMillis,
+                              Jetty94ClientCreator clientCreator,
+                              final org.slf4j.Logger logger)
+    {
+        this.maximumRetries = maximumRetries;
+        this.initialRetryIntervalMillis = initialRetryIntervalMillis;
+        this.maximumRetryIntervalMillis = maximumRetryIntervalMillis;
+        try {
+            this.clientStarted = clientCreator.createAndStart();
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        this.closeAutomatically = true;
+        this.logger = logger;
+    }
+
+    /**
+     * Creates a {@code Jetty93RetryHelper} instance with a ready-made Jetty 9.3 {@code HttpClient} instance.
+     *
+     * Note that the {@code HttpClient} instance is not automatically closed.
+     */
+    public static Jetty94RetryHelper createWithReadyMadeClient(int maximumRetries,
+                                                               int initialRetryIntervalMillis,
+                                                               int maximumRetryIntervalMillis,
+                                                               final org.eclipse.jetty.client.HttpClient clientStarted,
+                                                               final org.slf4j.Logger logger)
+    {
+        return new Jetty94RetryHelper(maximumRetries,
+                                      initialRetryIntervalMillis,
+                                      maximumRetryIntervalMillis,
+                                      clientStarted,
+                                      false,
+                                      logger);
+    }
+
+    private Jetty94RetryHelper(int maximumRetries,
+                               int initialRetryIntervalMillis,
+                               int maximumRetryIntervalMillis,
+                               final org.eclipse.jetty.client.HttpClient clientStarted,
+                               boolean closeAutomatically,
+                               final org.slf4j.Logger logger)
+    {
+        this.maximumRetries = maximumRetries;
+        this.initialRetryIntervalMillis = initialRetryIntervalMillis;
+        this.maximumRetryIntervalMillis = maximumRetryIntervalMillis;
+        this.logger = logger;
+        this.clientStarted = clientStarted;
+        this.closeAutomatically = closeAutomatically;
+    }
+
+    public <T> T requestWithRetry(final Jetty94ResponseReader<T> responseReader,
+                                  final Jetty94SingleRequester singleRequester)
+    {
+        try {
+            return RetryExecutor.builder()
+                .withRetryLimit(this.maximumRetries)
+                .withInitialRetryWaitMillis(this.initialRetryIntervalMillis)
+                .withMaxRetryWaitMillis(this.maximumRetryIntervalMillis)
+                .build()
+                .runInterruptible(new Retryable<T>() {
+                        @Override
+                        public T call()
+                                throws Exception
+                        {
+                            Response.Listener listener = responseReader.getListener();
+                            singleRequester.requestOnce(clientStarted, listener);
+                            Response response = responseReader.getResponse();
+                            if (response.getStatus() / 100 != 2) {
+                                final String errorResponseBody;
+                                try {
+                                    errorResponseBody = responseReader.readResponseContentInString();
+                                }
+                                catch (Exception ex) {
+                                    throw new HttpResponseException(
+                                        "Response not 2xx: "
+                                        + response.getStatus() + " "
+                                        + response.getReason() + " "
+                                        + "Response body not available by: " + Util.getStackTraceAsString(ex),
+                                        response);
+                                }
+                                throw new HttpResponseException(
+                                    "Response not 2xx: "
+                                    + response.getStatus() + " "
+                                    + response.getReason() + " "
+                                    + errorResponseBody,
+                                    response);
+                            }
+                            return responseReader.readResponseContent();
+                        }
+
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            return singleRequester.toRetry(exception);
+                        }
+
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                                throws RetryGiveupException
+                        {
+                            String message = String.format(
+                                Locale.ENGLISH, "Retrying %d/%d after %d seconds. Message: %s",
+                                retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                            if (retryCount % 3 == 0) {
+                                logger.warn(message, exception);
+                            }
+                            else {
+                                logger.warn(message);
+                            }
+                        }
+
+                        @Override
+                        public void onGiveup(Exception first, Exception last)
+                                throws RetryGiveupException
+                        {
+                        }
+                    });
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            // InterruptedException must not be RuntimeException.
+            throw new RuntimeException(ex);
+        }
+        catch (RetryGiveupException ex) {
+            if (ex.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) ex.getCause();
+            }
+            throw new RuntimeException(ex.getCause());
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if (this.closeAutomatically && this.clientStarted != null) {
+            try {
+                if (this.clientStarted.isStarted()) {
+                    this.clientStarted.stop();
+                }
+            }
+            catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+            finally {
+                this.clientStarted.destroy();
+            }
+        }
+    }
+
+    private final int maximumRetries;
+    private final int initialRetryIntervalMillis;
+    private final int maximumRetryIntervalMillis;
+    private final org.eclipse.jetty.client.HttpClient clientStarted;
+    private final org.slf4j.Logger logger;
+    private final boolean closeAutomatically;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94RetryHelper.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94RetryHelper.java
@@ -65,7 +65,7 @@ public class Jetty94RetryHelper
     }
 
     /**
-     * Creates a {@code Jetty93RetryHelper} instance with a ready-made Jetty 9.3 {@code HttpClient} instance.
+     * Creates a {@code Jetty94RetryHelper} instance with a ready-made Jetty 9.4 {@code HttpClient} instance.
      *
      * Note that the {@code HttpClient} instance is not automatically closed.
      */

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94SingleRequester.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94SingleRequester.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+/**
+ * Jetty93SingleRequester is to define a single request to the target REST service to be ready for retries.
+ *
+ * It is expected to use with {@link Jetty94RetryHelper} as follows.
+ *
+ * <pre>{@code
+ * InputStream inputStream = jetty93RetryHelper.requestWithRetry(
+ *     new InputStreamJetty93ResponseEntityReader(),
+ *     new Jetty93SingleRequester() {
+ *         @Override
+ *         public void requestOnce(org.eclipse.jetty.client.HttpClient client,
+ *                                 org.eclipse.jetty.client.api.Response.Listener listener)
+ *         {
+ *             client.newRequest("https://example.com/api/resource").method(HttpMethod.GET).send(listener);
+ *         }
+ *
+ *         @Override
+ *         public boolean isResponseStatusToRetry(org.eclipse.jetty.client.api.Response response)
+ *         {
+ *             return (response.getStatus() / 100) == 4;
+ *         }
+ *     });
+ * }</pre>
+ *
+ * @see Jetty94ResponseReader
+ * @see InputStreamJetty94ResponseEntityReader
+ */
+public abstract class Jetty94SingleRequester
+{
+    /**
+     * Requests to the target service with the given {@code org.eclipse.jetty.client.HttpClient}.
+     *
+     * The response is provided to the specified {@code org.eclipse.jetty.client.api.Response.Listener} by Jetty.
+     * The method is {@code abstract} that must be overridden.
+     */
+    public abstract void requestOnce(org.eclipse.jetty.client.HttpClient client,
+                                     org.eclipse.jetty.client.api.Response.Listener responseListener);
+
+    /**
+     * Returns {@code true} if the given {@code Exception} from {@link Jetty94RetryHelper} is to retry.
+     *
+     * This method cannot be overridden. Override {@code isResponseStatusRetryable} and {@code isExceptionRetryable}
+     * instead. {@code isResponseStatusRetryable} is called for {@code org.eclipse.jetty.client.HttpResponseException}.
+     * {@code isExceptionRetryable} is called for other exceptions.
+     */
+    public final boolean toRetry(Exception exception) {
+        // Expects |org.eclipse.jetty.client.HttpResponseException| is throws in case of HTTP error status
+        // such as implemented in |Jetty93RetryHelper|.
+        if (exception instanceof org.eclipse.jetty.client.HttpResponseException) {
+            return isResponseStatusToRetry(((org.eclipse.jetty.client.HttpResponseException) exception).getResponse());
+        }
+        else {
+            return isExceptionToRetry(exception);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given {@code org.eclipse.jetty.client.api.Response} is to retry.
+     *
+     * This method is {@code abstract} to be overridden, and {@code protected} to be called from {@code isRetryable}.
+     */
+    protected abstract boolean isResponseStatusToRetry(org.eclipse.jetty.client.api.Response response);
+
+    /**
+     * Returns true if the given {@code Exception} is to retry.
+     *
+     * This method available to override, and {@code protected} to be called from {@code isRetryable}.
+     */
+    protected boolean isExceptionToRetry(Exception exception) {
+        return false;
+    }
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94SingleRequester.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Jetty94SingleRequester.java
@@ -17,14 +17,14 @@
 package org.embulk.util.retryhelper.jetty94;
 
 /**
- * Jetty93SingleRequester is to define a single request to the target REST service to be ready for retries.
+ * Jetty94SingleRequester is to define a single request to the target REST service to be ready for retries.
  *
  * It is expected to use with {@link Jetty94RetryHelper} as follows.
  *
  * <pre>{@code
- * InputStream inputStream = jetty93RetryHelper.requestWithRetry(
- *     new InputStreamJetty93ResponseEntityReader(),
- *     new Jetty93SingleRequester() {
+ * InputStream inputStream = jetty94RetryHelper.requestWithRetry(
+ *     new InputStreamJetty94ResponseEntityReader(),
+ *     new Jetty94SingleRequester() {
  *         @Override
  *         public void requestOnce(org.eclipse.jetty.client.HttpClient client,
  *                                 org.eclipse.jetty.client.api.Response.Listener listener)
@@ -63,7 +63,7 @@ public abstract class Jetty94SingleRequester
      */
     public final boolean toRetry(Exception exception) {
         // Expects |org.eclipse.jetty.client.HttpResponseException| is throws in case of HTTP error status
-        // such as implemented in |Jetty93RetryHelper|.
+        // such as implemented in |Jetty94RetryHelper|.
         if (exception instanceof org.eclipse.jetty.client.HttpResponseException) {
             return isResponseStatusToRetry(((org.eclipse.jetty.client.HttpResponseException) exception).getResponse());
         }

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/StringJetty94ResponseEntityReader.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/StringJetty94ResponseEntityReader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
+
+public class StringJetty94ResponseEntityReader
+        implements Jetty94ResponseReader<String>
+{
+    public StringJetty94ResponseEntityReader(long timeoutMillis)
+    {
+        this.listener = new InputStreamResponseListener();
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    @Override
+    public final Response.Listener getListener()
+    {
+        return this.listener;
+    }
+
+    @Override
+    public final Response getResponse()
+            throws Exception
+    {
+        return this.listener.get(this.timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public final String readResponseContent()
+            throws Exception
+    {
+        return Util.asString(this.listener.getInputStream());
+    }
+
+    @Override
+    public final String readResponseContentInString()
+            throws Exception
+    {
+        return this.readResponseContent();
+    }
+
+    private final InputStreamResponseListener listener;
+    private final long timeoutMillis;
+}

--- a/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Util.java
+++ b/embulk-util-retryhelper-jetty94/src/main/java/org/embulk/util/retryhelper/jetty94/Util.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.retryhelper.jetty94;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+final class Util {
+    private Util() {
+        // No instantiation.
+    }
+
+    static String getStackTraceAsString(final Throwable throwable) {
+        final StringWriter errors = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(errors));
+        return errors.toString();
+    }
+
+    static String asString(final InputStream inputStream) throws IOException {
+        try {
+            return asString(inputStream, StandardCharsets.UTF_8);
+        } catch (final UnsupportedEncodingException ex) {
+            throw new UncheckedIOException("Unexpected failure: UTF-8 should be supported.", ex);
+        }
+    }
+
+    static String asString(final InputStream inputStream, final Charset charset) throws IOException {
+        return asByteArrayOutputStream(inputStream).toString(charset.toString());
+    }
+
+    static ByteArrayOutputStream asByteArrayOutputStream(final InputStream inputStream) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final byte[] buffer = new byte[1024];
+        while (true) {
+            final int length = inputStream.read(buffer);
+            if (length < 0) {
+                break;
+            }
+            output.write(buffer, 0, length);
+        }
+        return output;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = "embulk-util-retryhelper"
 include 'embulk-util-retryhelper-jaxrs'
 include 'embulk-util-retryhelper-jetty92'
 include 'embulk-util-retryhelper-jetty93'
+include 'embulk-util-retryhelper-jetty94'


### PR DESCRIPTION
The new JVM uses TLS 1.3 as default, but Jetty 92 and Jetty 93 don’t support TLS 1.3 (https://github.com/eclipse/jetty.project/issues/5073). This PR will add a Jetty 94 to support TLS 1.3. Thanks